### PR TITLE
Feature/hang fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "pio"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Tuomas Siipola <tuomas@zpl.fi>"]
 edition = "2018"
 license = "AGPL-3.0-or-later"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "pio"
-version = "0.1.2"
+version = "0.1.4"
 authors = ["Tuomas Siipola <tuomas@zpl.fi>"]
 edition = "2018"
 license = "AGPL-3.0-or-later"

--- a/src/main.rs
+++ b/src/main.rs
@@ -285,7 +285,9 @@ fn compress_image(
         fs::write(output_path, buffer).map_err(|err| err.to_string())?;
     } else {
         eprintln!("Failed to optimize the input image, copying the input image to output...");
-        fs::copy(input_path, output_path).map_err(|err| err.to_string())?;
+        if input_path != output_path {
+            fs::copy(input_path, output_path).map_err(|err| err.to_string())?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
Fix hang when optimized image is larger than original image and input and output paths are the same